### PR TITLE
Slackスラッシュコマンドへのサブコマンド追加（請求書の一覧・集計・未収金確認機能等の実装）

### DIFF
--- a/incra_api_server/src/infrastructure/slack.go
+++ b/incra_api_server/src/infrastructure/slack.go
@@ -156,6 +156,236 @@ func SendPaymentRejectedDM(slackUserId string, invoice domain.Invoice) error {
 	return nil
 }
 
+func invoiceStatusLabel(status domain.InvoiceStatus) string {
+	switch status {
+	case domain.InvoiceStatusDraft:
+		return "下書き"
+	case domain.InvoiceStatusSent:
+		return "送付済（支払い待ち）"
+	case domain.InvoiceStatusPaid:
+		return "支払い報告済（確認待ち）"
+	case domain.InvoiceStatusConfirmed:
+		return "確認済み"
+	case domain.InvoiceStatusCancelled:
+		return "キャンセル"
+	default:
+		return string(status)
+	}
+}
+
+func BuildHelpBlocks(cmd string) []slacklib.Block {
+	header := slacklib.NewHeaderBlock(
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, cmd+" コマンド一覧", false, false),
+	)
+	commands := []struct{ cmd, desc string }{
+		{cmd, "請求書作成モーダルを開く"},
+		{cmd + " new", "請求書作成モーダルを開く"},
+		{cmd + " help", "このヘルプを表示"},
+		{cmd + " list", "自分が発行した請求書（直近5件）"},
+		{cmd + " issued", "自分が発行した請求書（直近5件）"},
+		{cmd + " received", "自分が支払うべき請求書（直近5件）"},
+		{cmd + " pay", "自分が支払うべき請求書（直近5件）"},
+		{cmd + " unpaid", "自分が発行した未収金（sent + paid）"},
+		{cmd + " summary", "発行済み・受領済みのステータス別集計"},
+	}
+	blocks := []slacklib.Block{header}
+	for _, c := range commands {
+		text := fmt.Sprintf("*`%s`*\n%s", c.cmd, c.desc)
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, text, false, false),
+			nil, nil,
+		))
+	}
+	return blocks
+}
+
+func BuildIssuedListBlocks(invoices []domain.Invoice, webBaseURL string) []slacklib.Block {
+	header := slacklib.NewHeaderBlock(
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "発行済み請求書（直近5件）", false, false),
+	)
+	blocks := []slacklib.Block{header}
+	if len(invoices) == 0 {
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, "発行済み請求書はありません", false, false),
+			nil, nil,
+		))
+		return blocks
+	}
+	for _, inv := range invoices {
+		text := fmt.Sprintf("*%s*  宛先: %s  ¥%s  期限: %s  %s",
+			inv.InvoiceId, inv.BillingClientName, slackFormatAmount(inv.TotalAmount), inv.DueDate, invoiceStatusLabel(inv.Status))
+		btn := slacklib.NewButtonBlockElement(
+			"view_invoice",
+			inv.InvoiceId,
+			slacklib.NewTextBlockObject(slacklib.PlainTextType, "詳細", false, false),
+		)
+		btn.URL = fmt.Sprintf("%s/invoices/%s", webBaseURL, inv.InvoiceId)
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, text, false, false),
+			nil,
+			slacklib.NewAccessory(btn),
+		))
+	}
+	return blocks
+}
+
+func BuildReceivedListBlocks(invoices []domain.Invoice, webBaseURL string) []slacklib.Block {
+	header := slacklib.NewHeaderBlock(
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "支払いが必要な請求書（直近5件）", false, false),
+	)
+	blocks := []slacklib.Block{header}
+	if len(invoices) == 0 {
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, "支払いが必要な請求書はありません", false, false),
+			nil, nil,
+		))
+		return blocks
+	}
+	for _, inv := range invoices {
+		text := fmt.Sprintf("*%s*  発行者: %s  ¥%s  期限: %s",
+			inv.InvoiceId, inv.IssuerSlackRealName, slackFormatAmount(inv.TotalAmount), inv.DueDate)
+		btn := slacklib.NewButtonBlockElement(
+			"view_invoice",
+			inv.InvoiceId,
+			slacklib.NewTextBlockObject(slacklib.PlainTextType, "詳細", false, false),
+		)
+		btn.URL = fmt.Sprintf("%s/invoices/%s", webBaseURL, inv.InvoiceId)
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, text, false, false),
+			nil,
+			slacklib.NewAccessory(btn),
+		))
+	}
+	return blocks
+}
+
+func BuildUnpaidBlocks(sent []domain.Invoice, paid []domain.Invoice, webBaseURL string) []slacklib.Block {
+	header := slacklib.NewHeaderBlock(
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "未収金レポート", false, false),
+	)
+	blocks := []slacklib.Block{header}
+	if len(sent) == 0 && len(paid) == 0 {
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, "未収金はありません 🎉", false, false),
+			nil, nil,
+		))
+		return blocks
+	}
+	if len(sent) > 0 {
+		total := 0
+		for _, inv := range sent {
+			total += inv.TotalAmount
+		}
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType,
+				fmt.Sprintf("*支払い待ち（%d件）* 合計: ¥%s", len(sent), slackFormatAmount(total)),
+				false, false),
+			nil, nil,
+		))
+		for _, inv := range sent {
+			text := fmt.Sprintf("• %s  宛先: %s  ¥%s  期限: %s",
+				inv.InvoiceId, inv.BillingClientName, slackFormatAmount(inv.TotalAmount), inv.DueDate)
+			blocks = append(blocks, slacklib.NewSectionBlock(
+				slacklib.NewTextBlockObject(slacklib.MarkdownType, text, false, false),
+				nil, nil,
+			))
+		}
+	}
+	if len(paid) > 0 {
+		total := 0
+		for _, inv := range paid {
+			total += inv.TotalAmount
+		}
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType,
+				fmt.Sprintf("*確認待ち（%d件）* 合計: ¥%s", len(paid), slackFormatAmount(total)),
+				false, false),
+			nil, nil,
+		))
+		for _, inv := range paid {
+			text := fmt.Sprintf("• %s  宛先: %s  ¥%s  期限: %s",
+				inv.InvoiceId, inv.BillingClientName, slackFormatAmount(inv.TotalAmount), inv.DueDate)
+			blocks = append(blocks, slacklib.NewSectionBlock(
+				slacklib.NewTextBlockObject(slacklib.MarkdownType, text, false, false),
+				nil, nil,
+			))
+		}
+	}
+	return blocks
+}
+
+func BuildSummaryBlocks(issued []domain.Invoice, received []domain.Invoice, webBaseURL string) []slacklib.Block {
+	header := slacklib.NewHeaderBlock(
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "請求書サマリー", false, false),
+	)
+	blocks := []slacklib.Block{header}
+
+	countByStatus := func(invoices []domain.Invoice) map[domain.InvoiceStatus]struct{ count, total int } {
+		m := map[domain.InvoiceStatus]struct{ count, total int }{}
+		for _, inv := range invoices {
+			e := m[inv.Status]
+			e.count++
+			e.total += inv.TotalAmount
+			m[inv.Status] = e
+		}
+		return m
+	}
+
+	statuses := []domain.InvoiceStatus{
+		domain.InvoiceStatusDraft,
+		domain.InvoiceStatusSent,
+		domain.InvoiceStatusPaid,
+		domain.InvoiceStatusConfirmed,
+		domain.InvoiceStatusCancelled,
+	}
+
+	renderSection := func(title string, invoices []domain.Invoice) {
+		blocks = append(blocks, slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, fmt.Sprintf("*%s*", title), false, false),
+			nil, nil,
+		))
+		m := countByStatus(invoices)
+		var fields []*slacklib.TextBlockObject
+		for _, s := range statuses {
+			e := m[s]
+			if e.count == 0 {
+				continue
+			}
+			fields = append(fields,
+				slacklib.NewTextBlockObject(slacklib.MarkdownType,
+					fmt.Sprintf("*%s*\n%d件 / ¥%s", invoiceStatusLabel(s), e.count, slackFormatAmount(e.total)),
+					false, false),
+			)
+		}
+		if len(fields) == 0 {
+			blocks = append(blocks, slacklib.NewSectionBlock(
+				slacklib.NewTextBlockObject(slacklib.MarkdownType, "該当なし", false, false),
+				nil, nil,
+			))
+		} else {
+			blocks = append(blocks, slacklib.NewSectionBlock(nil, fields, nil))
+		}
+	}
+
+	renderSection("発行済み", issued)
+	renderSection("受領済み", received)
+
+	blocks = append(blocks, slacklib.NewContextBlock("",
+		slacklib.NewTextBlockObject(slacklib.MarkdownType, "直近100件の集計", false, false),
+	))
+	return blocks
+}
+
+func BuildUnknownCommandBlocks(text string) []slacklib.Block {
+	msg := fmt.Sprintf("不明なコマンド: `%s`\n`/incra help` で確認できます", text)
+	return []slacklib.Block{
+		slacklib.NewSectionBlock(
+			slacklib.NewTextBlockObject(slacklib.MarkdownType, msg, false, false),
+			nil, nil,
+		),
+	}
+}
+
 func slackFormatAmount(amount int) string {
 	s := strconv.Itoa(amount)
 	n := len(s)

--- a/incra_api_server/src/ui/hundler.go
+++ b/incra_api_server/src/ui/hundler.go
@@ -391,20 +391,108 @@ func (s *ServerImpl) SlackSlashsHandler(c echo.Context) error {
 		return err
 	}
 
+	subcommand := strings.TrimSpace(strings.ToLower(slashCommand.Text))
+	switch subcommand {
+	case "", "new":
+		return s.handleSlashNew(c, api, slashCommand)
+	case "help":
+		return s.handleSlashHelp(c, slashCommand.Command)
+	case "list", "issued":
+		return s.handleSlashIssued(c, slashCommand.UserID)
+	case "received", "pay":
+		return s.handleSlashReceived(c, slashCommand.UserID)
+	case "unpaid":
+		return s.handleSlashUnpaid(c, slashCommand.UserID)
+	case "summary":
+		return s.handleSlashSummary(c, slashCommand.UserID)
+	default:
+		return s.handleSlashUnknown(c, slashCommand.Text)
+	}
+}
+
+func (s *ServerImpl) handleSlashNew(c echo.Context, api *slack.Client, slashCommand slack.SlashCommand) error {
 	meta := SlackModalMetadata{IssuerID: slashCommand.UserID, ItemCount: 1}
 	modalView, err := buildInvoiceModalView(meta)
 	if err != nil {
 		fmt.Printf("failed to build modal: %v\n", err)
 		return c.JSON(http.StatusOK, map[string]string{"text": "モーダルの構築に失敗しました"})
 	}
-
 	_, err = api.OpenView(slashCommand.TriggerID, modalView)
 	if err != nil {
 		fmt.Printf("failed to open modal: %v\n", err)
 		return c.JSON(http.StatusOK, map[string]string{"text": "モーダルの表示に失敗しました"})
 	}
-
 	return c.String(http.StatusOK, "")
+}
+
+func (s *ServerImpl) handleSlashHelp(c echo.Context, cmd string) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"response_type": "ephemeral",
+		"blocks":        infrastructure.BuildHelpBlocks(cmd),
+	})
+}
+
+func (s *ServerImpl) handleSlashIssued(c echo.Context, userID string) error {
+	webBaseURL := os.Getenv("WEB_BASE_URL")
+	invoices, _, err := s.invoiceUseCase.ListInvoices(userID, "", 5, "")
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]string{"text": "請求書の取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"response_type": "ephemeral",
+		"blocks":        infrastructure.BuildIssuedListBlocks(invoices, webBaseURL),
+	})
+}
+
+func (s *ServerImpl) handleSlashReceived(c echo.Context, userID string) error {
+	webBaseURL := os.Getenv("WEB_BASE_URL")
+	invoices, _, err := s.invoiceUseCase.ListReceivedInvoices(userID, "sent", 5, "")
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]string{"text": "請求書の取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"response_type": "ephemeral",
+		"blocks":        infrastructure.BuildReceivedListBlocks(invoices, webBaseURL),
+	})
+}
+
+func (s *ServerImpl) handleSlashUnpaid(c echo.Context, userID string) error {
+	webBaseURL := os.Getenv("WEB_BASE_URL")
+	sent, _, err := s.invoiceUseCase.ListInvoices(userID, "sent", 100, "")
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]string{"text": "請求書の取得に失敗しました"})
+	}
+	paid, _, err := s.invoiceUseCase.ListInvoices(userID, "paid", 100, "")
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]string{"text": "請求書の取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"response_type": "ephemeral",
+		"blocks":        infrastructure.BuildUnpaidBlocks(sent, paid, webBaseURL),
+	})
+}
+
+func (s *ServerImpl) handleSlashSummary(c echo.Context, userID string) error {
+	webBaseURL := os.Getenv("WEB_BASE_URL")
+	issued, _, err := s.invoiceUseCase.ListInvoices(userID, "", 100, "")
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]string{"text": "請求書の取得に失敗しました"})
+	}
+	received, _, err := s.invoiceUseCase.ListReceivedInvoices(userID, "", 100, "")
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]string{"text": "請求書の取得に失敗しました"})
+	}
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"response_type": "ephemeral",
+		"blocks":        infrastructure.BuildSummaryBlocks(issued, received, webBaseURL),
+	})
+}
+
+func (s *ServerImpl) handleSlashUnknown(c echo.Context, text string) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"response_type": "ephemeral",
+		"blocks":        infrastructure.BuildUnknownCommandBlocks(text),
+	})
 }
 
 func (s *ServerImpl) SlackInteractionHandler(c echo.Context) error {


### PR DESCRIPTION
## 概要
Slackのスラッシュコマンドを拡張し、複数のサブコマンドを追加しました。
これにより、請求書の作成だけでなく、発行・受領した請求書の一覧表示、未収金の確認、ステータス別の集計などをSlack上から直接確認できるようになります。

## 変更内容
1. **サブコマンドのルーティング処理追加**
   - `ui/hundler.go` の `SlackSlashsHandler` を改修し、入力されたテキストに応じたサブコマンドの振り分け処理を追加しました。
   - 各コマンドに対応するハンドラー関数（`handleSlashHelp`, `handleSlashIssued`, `handleSlashReceived`, `handleSlashUnpaid`, `handleSlashSummary` など）を実装しました。

2. **Slack Block Kit UI構築処理の追加**
   - `infrastructure/slack.go` に、各コマンドのレスポンス用のSlack Blockを生成する関数（`BuildHelpBlocks`, `BuildIssuedListBlocks` など）を追加しました。
   - 請求書のステータス（Draft, Sent, Paidなど）を日本語ラベルに変換する `invoiceStatusLabel` メソッドを追加しました。

### 利用可能になるコマンド
- `(なし)` または `new`: 請求書作成モーダルを開く（従来の動作）
- `help`: コマンドの一覧とヘルプを表示する
- `list` または `issued`: 自分が発行した請求書（直近5件）を表示する
- `received` または `pay`: 自分が支払うべき請求書（直近5件）を表示する
- `unpaid`: 自分が発行した未収金（送付済および支払い報告済の請求書）の合計額とリストを表示する
- `summary`: 発行済み・受領済みの請求書をステータス別に集計して表示する（直近100件対象）
- `(不明なコマンド)`: エラーメッセージとともに `help` の使用を促すメッセージを表示する

## 備考・影響範囲
- 追加した各サブコマンドの結果は `ephemeral` メッセージとして返されるため、コマンドを実行したユーザー自身にのみ表示されます（チャンネルを汚しません）。
- 詳細ボタンのリンク先URLは、環境変数 `WEB_BASE_URL` を参照して構築されます。