### PR TITLE
feat: add Slack App Home tab with invoice management UI

### DIFF
--- a/incra_api_server/src/infrastructure/slack.go
+++ b/incra_api_server/src/infrastructure/slack.go
@@ -386,6 +386,65 @@ func BuildUnknownCommandBlocks(text string) []slacklib.Block {
 	}
 }
 
+func BuildHomeTabView(webBaseURL string) slacklib.HomeTabViewRequest {
+	headerBlock := slacklib.NewHeaderBlock(
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "Incra - 請求書管理", false, false),
+	)
+
+	descSection := slacklib.NewSectionBlock(
+		slacklib.NewTextBlockObject(slacklib.MarkdownType,
+			"Slackから請求書の発行・管理ができます。\n`/incra help` でコマンド一覧を確認できます。",
+			false, false),
+		nil, nil,
+	)
+
+	issueBtn := slacklib.NewButtonBlockElement(
+		"open_invoice_modal",
+		"open_invoice_modal",
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "請求書を発行する", false, false),
+	)
+	issueBtn.Style = slacklib.StylePrimary
+
+	actionsBlock := slacklib.NewActionBlock("home_actions", issueBtn)
+
+	divider := slacklib.NewDividerBlock()
+
+	webLinksHeader := slacklib.NewSectionBlock(
+		slacklib.NewTextBlockObject(slacklib.MarkdownType, "*Webアプリで確認する*", false, false),
+		nil, nil,
+	)
+
+	issuedBtn := slacklib.NewButtonBlockElement(
+		"web_issued",
+		"web_issued",
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "発行した請求書", false, false),
+	)
+	issuedBtn.URL = webBaseURL + "/invoices?type=issued"
+
+	receivedBtn := slacklib.NewButtonBlockElement(
+		"web_received",
+		"web_received",
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "受領した請求書", false, false),
+	)
+	receivedBtn.URL = webBaseURL + "/invoices?type=received"
+
+	newInvoiceBtn := slacklib.NewButtonBlockElement(
+		"web_new",
+		"web_new",
+		slacklib.NewTextBlockObject(slacklib.PlainTextType, "Web画面で請求書作成", false, false),
+	)
+	newInvoiceBtn.URL = webBaseURL + "/invoices/new"
+
+	webLinksBlock := slacklib.NewActionBlock("home_web_links", issuedBtn, receivedBtn, newInvoiceBtn)
+
+	return slacklib.HomeTabViewRequest{
+		Type: slacklib.VTHomeTab,
+		Blocks: slacklib.Blocks{
+			BlockSet: []slacklib.Block{headerBlock, descSection, actionsBlock, divider, webLinksHeader, webLinksBlock},
+		},
+	}
+}
+
 func slackFormatAmount(amount int) string {
 	s := strconv.Itoa(amount)
 	n := len(s)

--- a/incra_api_server/src/ui/hundler.go
+++ b/incra_api_server/src/ui/hundler.go
@@ -261,6 +261,14 @@ func (s *ServerImpl) SlackEventsHandler(c echo.Context) error {
 					return err
 				}
 			}
+		case *slackevents.AppHomeOpenedEvent:
+			if event.Tab == "home" {
+				webBaseURL := os.Getenv("WEB_BASE_URL")
+				homeView := infrastructure.BuildHomeTabView(webBaseURL)
+				if _, err := api.PublishView(event.User, homeView, ""); err != nil {
+					fmt.Printf("failed to publish home tab view: %v\n", err)
+				}
+			}
 		}
 
 	}
@@ -667,6 +675,18 @@ func (s *ServerImpl) handleBlockActions(c echo.Context, interaction slack.Intera
 	var successMessage string
 
 	switch action.ActionID {
+	case "open_invoice_modal":
+		meta := SlackModalMetadata{IssuerID: changedByUserId, ItemCount: 1}
+		modalView, err := buildInvoiceModalView(meta)
+		if err != nil {
+			fmt.Printf("failed to build modal: %v\n", err)
+			return c.String(http.StatusOK, "")
+		}
+		_, err = api.OpenView(interaction.TriggerID, modalView)
+		if err != nil {
+			fmt.Printf("failed to open modal from home tab: %v\n", err)
+		}
+		return c.String(http.StatusOK, "")
 	case "add_item_action":
 		var meta SlackModalMetadata
 		if err := json.Unmarshal([]byte(interaction.View.PrivateMetadata), &meta); err != nil {


### PR DESCRIPTION
## Summary

Slack の App Home タブを活用した請求書管理 UI を追加します。

- `app_home_opened` イベント受信時に Home タブ View を `views.publish` で表示
- Home タブに「請求書を発行する」ボタンを追加（クリックで請求書作成モーダルを起動）
- Home タブに Webアプリへのリンクボタンを追加（発行済み・受領済み・新規作成）
- `handleBlockActions` に `open_invoice_modal` アクション処理を追加

## 変更ファイル

| ファイル | 変更内容 |
| --- | --- |
| `incra_api_server/src/infrastructure/slack.go` | `BuildHomeTabView` 関数を追加 |
| `incra_api_server/src/ui/hundler.go` | `AppHomeOpenedEvent` ハンドラと `open_invoice_modal` アクション処理を追加 |

## Test plan

- [ ] Slack App の App Home タブを開いて Home View が表示されることを確認
- [ ] 「請求書を発行する」ボタンをクリックして請求書作成モーダルが開くことを確認
- [ ] モーダルから請求書を作成して正常に処理されることを確認
- [ ] 「発行した請求書」「受領した請求書」「Web画面で請求書作成」ボタンのリンクが正しいことを確認

## TODO

- [ ] `BuildHomeTabView` 内で `webBaseURL` のバリデーションを追加（空文字の場合はリンクボタンを非表示にする）
- [ ] `PublishView` 失敗時のエラーログを `fmt.Printf` から `c.Logger().Errorf` に変更し、エラーを返してリトライを促す

🤖 Generated with [Claude Code](https://claude.com/claude-code)