### PR TITLE
fix: PDFフォント非対応文字（絵文字）によるエラーを修正

### DIFF
--- a/pdf_generate/src/invoice_generator.py
+++ b/pdf_generate/src/invoice_generator.py
@@ -7,13 +7,19 @@ from reportlab.pdfbase import pdfmetrics
 from datetime import datetime
 from typing import List
 import os
+import re
+
+
+def _sanitize(text: str) -> str:
+    """絵文字など IPA明朝未収録の文字（Supplementary Multilingual Plane: U+10000以上）を除去する。"""
+    return ''.join(c for c in text if ord(c) <= 0xFFFF)
 
 class InvoiceGenerator:
     def __init__(self):
         self.font = os.getenv('FONT_NAME')
-        self.font_path =os.getenv('FONT_PATH')
+        self.font_path = os.getenv('FONT_PATH')
         print(self.font, self.font_path,"フォントを読み込みました")
-        
+
         pdfmetrics.registerFont(TTFont(self.font, self.font_path))
 
     @staticmethod
@@ -49,12 +55,12 @@ class InvoiceGenerator:
 
         # Payer
         c.setFont(self.font, 12)
-        c.drawString(50, height - 100, f"{payer_name} 御中")
+        c.drawString(50, height - 100, f"{_sanitize(payer_name)} 御中")
         c.drawString(50, height - 130, "下記の通り、ご請求申し上げます")
 
         # Invoice Amount
         c.setFont(self.font, 14)
-        c.drawString(50, height - 180, f"ご請求金額 ￥{self.format_amount(invoice_amount)}")
+        c.drawString(50, height - 180, f"ご請求金額 ¥{self.format_amount(invoice_amount)}")
         c.line(50, height - 185, 200, height - 185)
 
         # Payment Deadline
@@ -63,7 +69,7 @@ class InvoiceGenerator:
 
         # Sender Info
         c.setFont(self.font, 18)
-        c.drawRightString(width - 50, height - 180, sender_name)
+        c.drawRightString(width - 50, height - 180, _sanitize(sender_name))
 
         # Table Data
         header = ["取引日付", "内容", "数量", "単価", "金額", "概要"]
@@ -86,7 +92,7 @@ class InvoiceGenerator:
         # Total Amount
         total_amount = sum(int(row[4].replace(",", "")) for row in invoice_details)
         total_table = Table(
-            [["合計金額", f"￥{self.format_amount(total_amount)}"]],
+            [["合計金額", f"¥{self.format_amount(total_amount)}"]],
             colWidths=[150, table_width - 150],
             rowHeights=30
         )

--- a/pdf_generate/src/invoice_generator.py
+++ b/pdf_generate/src/invoice_generator.py
@@ -7,7 +7,6 @@ from reportlab.pdfbase import pdfmetrics
 from datetime import datetime
 from typing import List
 import os
-import re
 
 
 def _sanitize(text: str) -> str:
@@ -73,7 +72,8 @@ class InvoiceGenerator:
 
         # Table Data
         header = ["取引日付", "内容", "数量", "単価", "金額", "概要"]
-        data = [header] + invoice_details
+        sanitized_details = [[_sanitize(cell) if isinstance(cell, str) else cell for cell in row] for row in invoice_details]
+        data = [header] + sanitized_details
         x_offset, y_offset = 50, 350
         table_width = width - 100
         details_table = Table(data, colWidths=[70, 100, 50, 70, 70, 100], rowHeights=25)
@@ -110,7 +110,7 @@ class InvoiceGenerator:
 
         # Payment Information
         payment_table = Table(
-            [[payment_method, payment_account]],
+            [[payment_method, _sanitize(payment_account)]],
             colWidths=[150, table_width - 150],
             rowHeights=30
         )
@@ -128,7 +128,7 @@ class InvoiceGenerator:
         # Remarks
         if remarks:
             remarks_table = Table(
-                [["備考", remarks]],
+                [["備考", _sanitize(remarks)]],
                 colWidths=[150, table_width - 150],
                 rowHeights=45
             )

--- a/pdf_generate/tests/test_invoice_generator.py
+++ b/pdf_generate/tests/test_invoice_generator.py
@@ -1,0 +1,131 @@
+import os
+import sys
+import unittest
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from invoice_generator import _sanitize, InvoiceGenerator
+
+
+class TestSanitize(unittest.TestCase):
+    def test_ascii(self):
+        self.assertEqual(_sanitize("hello"), "hello")
+
+    def test_japanese(self):
+        self.assertEqual(_sanitize("山田太郎"), "山田太郎")
+
+    def test_emoji_removed(self):
+        self.assertEqual(_sanitize("Tomo🎵田中"), "Tomo田中")
+
+    def test_multiple_emoji_removed(self):
+        self.assertEqual(_sanitize("🌟abc🎉"), "abc")
+
+    def test_empty(self):
+        self.assertEqual(_sanitize(""), "")
+
+    def test_mixed_symbols(self):
+        self.assertEqual(_sanitize("株式会社ABC / 田中"), "株式会社ABC / 田中")
+
+
+class TestFormatAmount(unittest.TestCase):
+    def test_thousands(self):
+        self.assertEqual(InvoiceGenerator.format_amount(1000), "1,000")
+
+    def test_zero(self):
+        self.assertEqual(InvoiceGenerator.format_amount(0), "0")
+
+    def test_large(self):
+        self.assertEqual(InvoiceGenerator.format_amount(1000000), "1,000,000")
+
+
+class TestFormatDate(unittest.TestCase):
+    def test_slash_format(self):
+        self.assertEqual(InvoiceGenerator.format_date("2024/12/31"), "2024年12月31日")
+
+    def test_hyphen_format(self):
+        self.assertEqual(InvoiceGenerator.format_date("2026-04-20"), "2026年4月20日")
+
+    def test_invalid_month(self):
+        with self.assertRaises(ValueError):
+            InvoiceGenerator.format_date("2024/13/01")
+
+    def test_invalid_day(self):
+        with self.assertRaises(ValueError):
+            InvoiceGenerator.format_date("2024/04/31")
+
+    def test_invalid_feb(self):
+        with self.assertRaises(ValueError):
+            InvoiceGenerator.format_date("2024/02/30")
+
+
+class TestGenerateInvoice(unittest.TestCase):
+    def setUp(self):
+        os.environ['FONT_NAME'] = 'IPAexMincho'
+        os.environ['FONT_PATH'] = os.path.join(os.path.dirname(__file__), '..', 'src', 'ipam.ttf')
+        self.gen = InvoiceGenerator()
+
+    def test_generates_pdf_file(self):
+        with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+            output = f.name
+        try:
+            self.gen.generate_invoice(
+                payer_name="株式会社テスト",
+                sender_name="山田太郎",
+                invoice_amount=10000,
+                deadline="2024/12/31",
+                invoice_details=[["2024/11/01", "商品A", "1", "10,000", "10,000", ""]],
+                payment_method="銀行振込",
+                payment_account="〇〇銀行 普通 1234567",
+                remarks="",
+                output_file=output,
+            )
+            self.assertTrue(os.path.exists(output))
+            self.assertGreater(os.path.getsize(output), 0)
+        finally:
+            if os.path.exists(output):
+                os.remove(output)
+
+    def test_generates_pdf_with_emoji_in_name(self):
+        with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+            output = f.name
+        try:
+            self.gen.generate_invoice(
+                payer_name="Tomo🎵田中",
+                sender_name="送信者🌟",
+                invoice_amount=1000,
+                deadline="2026-04-20",
+                invoice_details=[["2026-04-20", "キャンセル料", "1", "1,000", "1,000", ""]],
+                payment_method="銀行振込",
+                payment_account="ことら送金",
+                remarks="",
+                output_file=output,
+            )
+            self.assertTrue(os.path.exists(output))
+        finally:
+            if os.path.exists(output):
+                os.remove(output)
+
+    def test_generates_pdf_without_remarks(self):
+        with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+            output = f.name
+        try:
+            self.gen.generate_invoice(
+                payer_name="テスト株式会社",
+                sender_name="送信者",
+                invoice_amount=5000,
+                deadline="2024/06/30",
+                invoice_details=[["2024/06/01", "サービス料", "1", "5,000", "5,000", "備考あり"]],
+                payment_method="銀行振込",
+                payment_account="△△銀行 普通 9999999",
+                remarks="",
+                output_file=output,
+            )
+            self.assertTrue(os.path.exists(output))
+        finally:
+            if os.path.exists(output):
+                os.remove(output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pdf_generate/tests/test_invoice_generator.py
+++ b/pdf_generate/tests/test_invoice_generator.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import tempfile
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
@@ -61,9 +62,13 @@ class TestFormatDate(unittest.TestCase):
 
 class TestGenerateInvoice(unittest.TestCase):
     def setUp(self):
-        os.environ['FONT_NAME'] = 'IPAexMincho'
-        os.environ['FONT_PATH'] = os.path.join(os.path.dirname(__file__), '..', 'src', 'ipam.ttf')
+        font_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'ipam.ttf')
+        self._env_patcher = patch.dict(os.environ, {'FONT_NAME': 'IPAexMincho', 'FONT_PATH': font_path})
+        self._env_patcher.start()
         self.gen = InvoiceGenerator()
+
+    def tearDown(self):
+        self._env_patcher.stop()
 
     def test_generates_pdf_file(self):
         with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:


### PR DESCRIPTION
## 概要

IPAex明朝フォントが対応していないサロゲートペア文字（絵文字など U+10000以上）が請求書の名前フィールドに含まれると、PDF生成が失敗するバグを修正。

## 変更内容

- `_sanitize()` 関数を追加: BMP外文字（U+10000以上）を除去してフォントエラーを防ぐ
- `payer_name` / `sender_name` に `_sanitize()` を適用
- 全角円記号 `￥`（U+FFE5）を半角 `¥`（U+00A5）に統一（フォント非対応対策）
- `_sanitize` / `format_amount` / `format_date` / `generate_invoice` のユニットテストを追加

## テスト

```bash
cd pdf_generate
python -m unittest tests/test_invoice_generator.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)